### PR TITLE
Refactored code from /rooms/:id to /:id/details

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -9,7 +9,7 @@ app.use(bodyParser.json());
 
 app.use(express.static(__dirname + '/../client/dist'));
 
-app.get('/rooms/:id', (req, res) => {
+app.get('/:id/details', (req, res) => {
   Room.findByID(req.params.id, (err, roomInfo) => {
     if (err) {
       res.status(404).json({error: `ID ${req.params.id} does not exist in database`});

--- a/server/app.test.js
+++ b/server/app.test.js
@@ -31,18 +31,18 @@ describe('server', () => {
   });
 
   describe('requests to /rooms/:id', () => {
-    test('it should return JSON with a \'data\' key for route \'rooms/1\'', (done) => {
+    test('it should return JSON with a \'data\' key for route \'1/details\'', (done) => {
       Room.findByID.mockImplementation((id, cb) => {
         cb(null, [{id: 'this is a test'}]);
       });
-      request.get('/rooms/1').then((response) => {
+      request.get('/1/details').then((response) => {
         expect(response.body).toHaveProperty('data');
         done();
       });
     });
 
     test('it should only return a single item inside the data key', (done) => {
-      request.get('/rooms/1').then((response) => {
+      request.get('/1/details').then((response) => {
         expect(response.body.data.length).toBe(1);
         done();
       });
@@ -52,14 +52,14 @@ describe('server', () => {
       Room.findByID.mockImplementation((id, cb) => {
         cb('error', null);
       });
-      request.get('/rooms/1').then((response) => {
+      request.get('/1/details').then((response) => {
         expect(response.statusCode).toBe(404);
         done();
       });
     });
 
     test('response message for the invalid message should contain the id', (done) => {
-      request.get('/rooms/1').then((response) => {
+      request.get('/1/details').then((response) => {
         expect(response.body.error).toBe('ID 1 does not exist in database');
         done();
       });


### PR DESCRIPTION
refactored my endpoint and tests based on a group discussion where we decided:

1. the proxy will hit `/rooms/:id`
2. our services will hit `/:id/service` as the end point. 

Thus my code now points to `/:id/details`